### PR TITLE
CreateRun: remove ApplicationID parameter

### DIFF
--- a/run.go
+++ b/run.go
@@ -64,8 +64,7 @@ func (c *Client) GetRuns(options *GetRunsOptions) ([]*RunSummary, error) {
 // CreateRunOptions are the options associated with Client.CreateRun.
 type CreateRunOptions struct {
 	// Required
-	ApplicationID string `json:"applicationId,omitempty"`
-	PipelineID    string `json:"pipelineId,omitempty"`
+	PipelineID string `json:"pipelineId,omitempty"`
 
 	// Optional
 	Branch     string   `json:"branch,omitempty"`


### PR DESCRIPTION
Endpoint never had support/checked for applicationID.

This parameter was probably there because the docs (for a while) stated that it was required.