### PR TITLE
add Runsteps model

### DIFF
--- a/client.go
+++ b/client.go
@@ -39,12 +39,12 @@ func (c *Client) Do(method string, urlTemplate *uritemplates.UriTemplate, urlMod
 		}
 		if m != nil {
 			path, err = urlTemplate.Expand(m)
-		} else {
-			path = urlTemplate.String()
+			if err != nil {
+				return err
+			}
 		}
-	}
-	if err != nil {
-		return err
+	} else {
+		path = urlTemplate.String()
 	}
 
 	var payloadReader io.Reader
@@ -80,7 +80,6 @@ func (c *Client) generateURL(path string) string {
 // payload
 func (c *Client) makeRequest(method string, path string, payload io.Reader) ([]byte, error) {
 	url := c.generateURL(path)
-
 	req, err := http.NewRequest(method, url, payload)
 	if err != nil {
 		return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -98,6 +98,7 @@ func TestClientNoUrlModel(t *testing.T) {
 	config := &Config{Endpoint: ts.URL}
 	client := NewClient(config)
 	c := make(map[string]string)
-	err := client.Do("GET", nil, nil, nil, &c)
+	template := userTemplates["GetUser"]
+	err := client.Do("GET", template, nil, nil, &c)
 	assert.NoError(t, err, "should not error")
 }

--- a/models.go
+++ b/models.go
@@ -75,9 +75,11 @@ type RunStep struct {
 	ArtifactsURL string              `json:"artifactsUrl"`
 	CreatedAt    time.Time           `json:"createdAt"`
 	FinishedAt   time.Time           `json:"finishedAt"`
+	Message      string              `json:"message"`
 	LogURL       string              `json:"logUrl"`
 	Order        int                 `json:"order"`
 	Application  *ApplicationSummary `json:"project"`
+	Phase        string              `json:"phase"`
 	Result       string              `json:"result"`
 	Run          *RunSummary         `json:"run"`
 	StartedAt    time.Time           `json:"startedAt"`

--- a/models.go
+++ b/models.go
@@ -68,6 +68,23 @@ type RunSummary struct {
 	Status     string    `json:"status"`
 }
 
+// RunStep is a detailed api representation
+type RunStep struct {
+	ID           string              `json:"id"`
+	URL          string              `json:"url"`
+	ArtifactsURL string              `json:"artifactsUrl"`
+	CreatedAt    time.Time           `json:"createdAt"`
+	FinishedAt   time.Time           `json:"finishedAt"`
+	LogURL       string              `json:"logUrl"`
+	Order        int                 `json:"order"`
+	Application  *ApplicationSummary `json:"project"`
+	Result       string              `json:"result"`
+	Run          *RunSummary         `json:"run"`
+	StartedAt    time.Time           `json:"startedAt"`
+	Status       string              `json:"status"`
+	Step         string              `json:"step"`
+}
+
 // Deploy is a detailed api representation
 type Deploy struct {
 	ID          string              `json:"id"`

--- a/runstep.go
+++ b/runstep.go
@@ -7,11 +7,13 @@ var runStepTemplates = make(map[string]*uritemplates.UriTemplate)
 
 func init() {
 	addURITemplate(runTemplates, "GetRunStep", "/api/v3/runsteps{/runStepId}")
+	addURITemplate(runTemplates, "GetRunStepLog", "/api/v3/runsteps{/runStepId}/log")
 }
 
 // RunStepService holds all runStep specific methods
 type RunStepService interface {
 	GetRunStep(options *GetRunStepOptions) (*RunStep, error)
+	GetRunStepLog(options *GetRunStepLogOptions) ([]byte, error)
 }
 
 // Ensure the client supports/adheres to the RunService interface
@@ -29,6 +31,24 @@ func (c *Client) GetRunStep(options *GetRunStepOptions) (*RunStep, error) {
 
 	result := &RunStep{}
 	err := c.Do(method, template, options, nil, result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetRunStepLogOptions are the options associated with Client.GetRunStep
+type GetRunStepLogOptions struct {
+	RunStepID string `map:"runStepId"`
+}
+
+// GetRunStepLog will retreive a single RunStepLog
+func (c *Client) GetRunStepLog(options *GetRunStepLogOptions) ([]byte, error) {
+	method := "GET"
+	template := runTemplates["GetRunStepLog"]
+
+	result, err := c.DoRaw(method, template, options, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/runstep.go
+++ b/runstep.go
@@ -1,0 +1,37 @@
+package werckerclient
+
+import "github.com/jtacoma/uritemplates"
+
+// runTemplates contains all UriTemplates indexed by name.
+var runStepTemplates = make(map[string]*uritemplates.UriTemplate)
+
+func init() {
+	addURITemplate(runTemplates, "GetRunStep", "/api/v3/runsteps{/runStepId}")
+}
+
+// RunStepService holds all runStep specific methods
+type RunStepService interface {
+	GetRunStep(options *GetRunStepOptions) (*RunStep, error)
+}
+
+// Ensure the client supports/adheres to the RunService interface
+var _ RunStepService = (*Client)(nil)
+
+// GetRunStepOptions are the options associated with Client.GetRunStep
+type GetRunStepOptions struct {
+	RunStepID string `map:"runStepId"`
+}
+
+// GetRunStep will retrieve a single RunStep
+func (c *Client) GetRunStep(options *GetRunStepOptions) (*RunStep, error) {
+	method := "GET"
+	template := runTemplates["GetRunStep"]
+
+	result := &RunStep{}
+	err := c.Do(method, template, options, nil, result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/users.go
+++ b/users.go
@@ -36,7 +36,7 @@ type UserService interface {
 
 func (c *Client) GetCurrentUser() (*User, error) {
 	method := "GET"
-	template := runTemplates["GetUser"]
+	template := userTemplates["GetUser"]
 
 	result := &User{}
 	err := c.Do(method, template, nil, nil, result)


### PR DESCRIPTION
#### Adds:
* RunStep model
* `RunStepService` interface 
* `GetRunStep`
* `GetRunStepLog` returns a []byte. This is because the endpoint is NOT returning valid JSON (plain text only)
* splits the Do method in `client.go` into two calls: `Do` & `DoRaw`. Where do `DoRaw` is called by `Do` and does most of the work (creating the payload, calling makeRequest etc), but without doing the unmarshal (still part of `Do`). This allows the `GetRunStepLog` call to use nearly all of same code normal json based api calls do.

includes #8 