### PR TITLE
Fix GetApplicationPipelines

### DIFF
--- a/application.go
+++ b/application.go
@@ -7,7 +7,7 @@ var applicationTemplates = make(map[string]*uritemplates.UriTemplate)
 
 func init() {
 	addURITemplate(applicationTemplates, "GetApplication", "/api/v3/applications{/owner,name}")
-	addURITemplate(applicationTemplates, "GetApplicationPipelines", "/api/v3/applications{/owner,name}/pipeline{?limit,skip}")
+	addURITemplate(applicationTemplates, "GetApplicationPipelines", "/api/v3/applications{/owner,name}/pipelines{?limit,skip}")
 }
 
 // GetApplicationOptions are the options associated with Client.GetApplication
@@ -68,14 +68,15 @@ type GetApplicationPipelinesOptions struct {
 }
 
 // GetApplicationPipelines will retrieve a list of of an Application's pipelines
-func (c *Client) GetApplicationPipeliness(options *GetApplicationPipelinesOptions) ([]Pipeline, error) {
+func (c *Client) GetApplicationPipelines(options *GetApplicationPipelinesOptions) ([]PipelineSummary, error) {
 	method := "GET"
 	template := applicationTemplates["GetApplicationPipelines"]
 
-	result := []Pipeline{}
+	result := []PipelineSummary{}
 	err := c.Do(method, template, options, nil, &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return result, nil
 }

--- a/application.go
+++ b/application.go
@@ -7,7 +7,7 @@ var applicationTemplates = make(map[string]*uritemplates.UriTemplate)
 
 func init() {
 	addURITemplate(applicationTemplates, "GetApplication", "/api/v3/applications{/owner,name}")
-	addURITemplate(applicationTemplates, "GetApplicationPipelines", "/api/v3/applications{/owner,name}/pipeline")
+	addURITemplate(applicationTemplates, "GetApplicationPipelines", "/api/v3/applications{/owner,name}/pipeline{?limit,skip}")
 }
 
 // GetApplicationOptions are the options associated with Client.GetApplication
@@ -57,8 +57,18 @@ func (c *Client) GetApplications(options *GetApplicationsOptions) ([]Application
 	return result, nil
 }
 
+type GetApplicationPipelinesOptions struct {
+	// Required
+	Owner string `map:"owner"`
+	Name  string `map:"name"`
+	
+	// Optional
+	Limit string `map:"limit,omitempty"`
+	Skip  int    `map:"skip,omitempty"`
+}
+
 // GetApplicationPipelines will retrieve a list of of an Application's pipelines
-func (c *Client) GetApplicationPipeliness(options *GetApplicationsOptions) ([]Pipeline, error) {
+func (c *Client) GetApplicationPipeliness(options *GetApplicationPipelinesOptions) ([]Pipeline, error) {
 	method := "GET"
 	template := applicationTemplates["GetApplicationPipelines"]
 


### PR DESCRIPTION
by adding a GetApplicationPipelinesOptions. The uritemplate is also expanded to support all available parameters.