### PR TITLE
CreateChainRun fix: use pipelineID

### DIFF
--- a/run.go
+++ b/run.go
@@ -104,7 +104,7 @@ func (c *Client) CreateRun(options *CreateRunOptions) (*Run, error) {
 type CreateChainRunOptions struct {
 	// Required
 	SourceRunID string `json:"sourceRunId,omitempty"`
-	TargetID    string `json:"targetId,omitempty"`
+	PipelineID  string `json:"pipelineId,omitempty"`
 
 	Message string   `json:"message,omitempty"`
 	EnvVars []EnvVar `json:"envVars,omitempty"`


### PR DESCRIPTION
Create-run endpoint requires pipelineID, not targetId.

Note: this pr also introduces a backwards incompatible change: changing the name in the option (so it matches the CreateRunOptions)